### PR TITLE
Document new installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Vim plugin for the [Stan probabilistic programming language](https://mc-stan.o
 - [Installation](#installation)
   - [Vundle, NeoBundle and VimPlug](#vundle-neobundle-and-vimplug)
   - [Pathogen](#pathogen)
+  - [Home Manager](#home-manager)
   - [Manual Installation](#manual-installation)
 - [Documentation](#documentation)
 - [Additional Screenshots](#additional-screenshots)
@@ -56,6 +57,21 @@ Run the following from the terminal:
 ```bash
 cd ~/.vim/bundle
 git clone https://github.com/eigenfoo/stan-vim
+```
+
+### Home Manager
+
+Nix users who manage their Vim plugins with Home Manager can grab `stan-vim` from nixpkgs:
+
+```nix
+{ pkgs, ... }:
+{
+  # or programs.neovim.plugins
+  programs.vim.plugins = with pkgs.vimPlugins; [
+    stan-vim
+    # ...
+  ];
+}
 ```
 
 ### Manual Installation


### PR DESCRIPTION
Hey team-

As of NixOS/nixpkgs#114036, folks will be able to install `stan-vim` from [nixpkgs](https://nixos.org/). I personally use a tool based on nix -- [Home Manager](https://github.com/nix-community/home-manager) -- to manage my vim plugins, which makes it tricky to _also_ use a purpose-built vim package manager or manual installation. This tweak to the README simply documents that new installation option for the small community of other people who manage their vim plugins and configuration this way.

Thanks for your consideration!