### PR TITLE
fix: hotfixes for Stan v2.33

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
 
 jobs:
   test:

--- a/syntax/stan.vim
+++ b/syntax/stan.vim
@@ -32,7 +32,7 @@ syntax keyword stanFunction bernoulli_logit
 syntax keyword stanFunction bernoulli_logit_lpmf bernoulli_logit_lupmf bernoulli_logit_rng
 
 syntax keyword stanFunction bernoulli_logit_glm
-syntax keyword stanFunction bernoulli_logit_glm_lpmf bernoulli_logit_glm_lupmf bernoulli_logit_glm_rand
+syntax keyword stanFunction bernoulli_logit_glm_lpmf bernoulli_logit_glm_lupmf bernoulli_logit_glm_rng
 
 syntax keyword stanFunction binomial
 syntax keyword stanFunction binomial_lpmf binomial_lupmf binomial_cdf binomial_lcdf binomial_lccdf binomial_rng
@@ -150,7 +150,7 @@ syntax keyword stanFunction rayleigh
 syntax keyword stanFunction rayleigh_lpdf rayleigh_lupdf rayleigh_cdf rayleigh_lcdf rayleigh_lccdf rayleigh_rng
 
 syntax keyword stanFunction loglogistic
-syntax keyword stanFunction loglogistic_lpdf loglogistic_cdf loglogistic_rng loglogistic_log
+syntax keyword stanFunction loglogistic_lpdf loglogistic_cdf loglogistic_rng
 
 syntax keyword stanFunction wiener
 syntax keyword stanFunction wiener_lpdf wiener_lupdf
@@ -168,7 +168,7 @@ syntax keyword stanFunction beta_proportion
 syntax keyword stanFunction beta_proportion_lpdf beta_proportion_lupdf beta_proportion_lcdf beta_proportion_lccdf beta_proportion_rng
 
 syntax keyword stanFunction von_mises
-syntax keyword stanFunction von_mises_lpdf von_mises_lupdf von_mises_lcdf von_mises_lccdf von_mises_rng
+syntax keyword stanFunction von_mises_lpdf von_mises_lupdf von_mises_cdf von_mises_lcdf von_mises_lccdf von_mises_rng
 
 syntax keyword stanFunction uniform
 syntax keyword stanFunction uniform_lpdf uniform_lupdf uniform_cdf uniform_lcdf uniform_lccdf uniform_rng
@@ -209,13 +209,11 @@ syntax keyword stanFunction lkj_corr_cholesky_lpdf lkj_corr_cholesky_lupdf lkj_c
 syntax keyword stanFunction wishart
 syntax keyword stanFunction wishart_lpdf wishart_lupdf wishart_rng
 
-syntax keyword stanFunction wishart_cholesky
 syntax keyword stanFunction wishart_cholesky_lpdf wishart_cholesky_lupdf wishart_cholesky_rng
 
 syntax keyword stanFunction inv_wishart
 syntax keyword stanFunction inv_wishart_lpdf inv_wishart_lupdf inv_wishart_rng
 
-syntax keyword stanFunction inv_wishart_cholesky
 syntax keyword stanFunction inv_wishart_cholesky_lpdf inv_wishart_cholesky_lupdf inv_wishart_cholesky_rng
 
 " Constants
@@ -223,14 +221,14 @@ syntax keyword stanConstant pi e sqrt2 log2 log10
 syntax keyword stanConstant not_a_number positive_infinity negative_infinity machine_precision
 
 " Built in functions
-syntax keyword stanFunction print
+syntax keyword stanFunction print arg
 syntax keyword stanFunction abs int_step min max
 syntax keyword stanFunction get_real get_imag
 syntax keyword stanFunction step is_inf is_nan fdim fmin fmax fmod floor ceil round trunc
 syntax keyword stanFunction sqrt cbrt square exp exp2 log log2 log10 pow inv inv_sqrt inv_square
 syntax keyword stanFunction hypot cos sin tan acos asin atan atan2
 syntax keyword stanFunction cosh sinh tanh acosh asinh atanh
-syntax keyword stanFunction logit inv_logit inv_cloglog
+syntax keyword stanFunction logit inv_logit inv_cloglog log_inv_logit_diff
 syntax keyword stanFunction erf erfc inv_erfc Phi inv_Phi Phi_approx binary_log_loss owens_t
 syntax keyword stanFunction std_normal_qf std_normal_log_qf
 syntax keyword stanFunction inc_beta inv_inc_beta lbeta tgamma lgamma digamma trigamma lmgamma gamma_p gamma_q choose
@@ -238,7 +236,7 @@ syntax keyword stanFunction bessel_first_kind bessel_second_kind modified_bessel
 syntax keyword stanFunction falling_factorial lchoose log_falling_factorial rising_factorial log_rising_factorial
 syntax keyword stanFunction expm1 fma ldexp lmultiply log1p log1m log1p_exp log1m_exp log_diff_exp log_mix log_sum_exp log_inv_logit log1m_inv_logit
 syntax keyword stanFunction lambert_w0 lambert_wm1
-syntax keyword stanFunction min max sum prod log_sum_exp mean variance sd distance squared_distance
+syntax keyword stanFunction min max sum prod log_sum_exp mean variance sd distance squared_distance quantile
 syntax keyword stanFunction dims num_elements size
 syntax keyword stanFunction rep_array
 syntax keyword stanFunction append_array
@@ -254,7 +252,7 @@ syntax keyword stanFunction linspaced_array linspaced_int_array linspaced_vector
 syntax keyword stanFunction col row block sub_col sub_row head tail segment
 syntax keyword stanFunction append_col append_row
 syntax keyword stanFunction softmax log_softmax cumulative_sum
-syntax keyword stanFunction gp_exp_quad_cov gp_dot_prod_cov gp_matern32_cov gp_matern52_cov gp_periodic_cov
+syntax keyword stanFunction gp_exponential_cov gp_exp_quad_cov gp_dot_prod_cov gp_matern32_cov gp_matern52_cov gp_periodic_cov cov_exp_quad
 syntax keyword stanFunction mdivide_left_tri_low mdivide_right_tri_low mdivide_left_spd mdivide_right_spd
 syntax keyword stanFunction matrix_exp matrix_exp_multiply scale_matrix_exp_multiply matrix_power trace determinant log_determinant log_determinant_spd
 syntax keyword stanFunction inverse inverse_spd chol2inv generalized_inverse eigenvalues_sym eigenvectors_sym qr_thin_Q qr_thin_R qr_Q qr_R cholesky_decompose singular_values svd_U svd_V
@@ -262,21 +260,21 @@ syntax keyword stanFunction qr qr_thin eigendecompose_sym eigendecompose complex
 syntax keyword stanFunction eigenvectors eigenvalues
 syntax keyword stanFunction sort_asc sort_desc sort_indices_asc sort_indices_desc rank
 syntax keyword stanFunction csr_extract_w csr_extract_v csr_extract_u csr_to_dense_matrix csr_matrix_times_vector
-syntax keyword stanFunction to_matrix to_vector to_row_vector to_array_2d to_array_1d to_complex
+syntax keyword stanFunction to_matrix to_vector to_row_vector to_array_2d to_array_1d to_complex to_int
 syntax keyword stanFunction algebra_solver algebra_solver_newton solve_newton solve_newton_tol solve_powell solve_powell_tol
 syntax keyword stanFunction ode_rk45 ode_rk45_tol ode_adams ode_adams_tol ode_bdf ode_bdf_tol ode_adjoint_tol_ctl ode_ckrk ode_ckrk_tol
 syntax keyword stanFunction dae dae_tol
 syntax keyword stanFunction reduce_sum reduce_sum_static
 syntax keyword stanFunction map_rect
 syntax keyword stanFunction fft inv_fft fft2 inv_fft2
-syntax keyword stanFunction L1 L2
 syntax keyword stanFunction complex_schur_decompose_t complex_schur_decompose_u
-syntax keyword stanFunction conj
+syntax keyword stanFunction conj polar proj
+syntax keyword stanFunction hmm_marginal hmm_latent_rng hmm_hidden_state_prob
+syntax keyword stanFunction norm norm1 norm2 
 
 " Deprecations
 syntax keyword stanFunction integrate_ode_rk45 integrate_ode integrate_ode_bdf integrate_ode_adams
 syntax keyword stanFunction integrate_1d
-syntax keyword stanFunction fabs
 
 " Control flow
 syntax keyword stanConditional if then else
@@ -299,11 +297,11 @@ syntax match stanOperator "\v\\"
 " Removed some, since they're highlighted in other places
 syntax keyword stanCppConflict var auto break continue export extern static struct true typedef void
 syntax keyword stanOperator return
-syntax keyword stanSpecial array lower upper offset multiplier log_prob_impl
+syntax keyword stanSpecial array lower upper offset multiplier
 syntax keyword stanKeyword target
 
 " To do
-syntax keyword stanTodo TODO FIXME
+syntax keyword stanTodo TODO FIXME NOTE WARN WARNING
 syntax match stanFuncDoc "@param"
 syntax match stanFuncDoc "@return"
 syntax cluster stanCommentGroup contains=stanTodo,stanFuncDoc


### PR DESCRIPTION
- Added all the missing ones from #12
- The only unnecessary are now 'array', 'multiplier', 'offset', 'upper', and 'lower'.

After this we are ready for a release @eigenfoo.
I can make a PR to `nixpkgs`.

I am also adding the CI tests to run on PRs.